### PR TITLE
Basic refactors

### DIFF
--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -166,6 +166,19 @@ class SquadQueue(commands.Cog):
             return False
         return True
 
+    @staticmethod
+    def queue_command_allowed(ctx_or_followup, mogi):
+        if mogi is None:
+            asyncio.create_task(ctx_or_followup.send("Queue has not started yet."))
+            return False
+        if not mogi.started:
+            asyncio.create_task(ctx_or_followup.send("Mogi has not been started yet... type !start"))
+            return False
+        if not mogi.gathering:
+            asyncio.create_task(ctx_or_followup.send("Mogi is closed; players cannot join or drop from the event"))
+            return False
+        return True
+
     @app_commands.command(name="c")
     @app_commands.guild_only()
     async def can(self, interaction: discord.Interaction):
@@ -173,8 +186,7 @@ class SquadQueue(commands.Cog):
         await interaction.response.defer()
         member = interaction.user
         mogi = self.get_mogi(interaction)
-        if mogi is None or not mogi.started or not mogi.gathering:
-            await interaction.followup.send("Queue has not started yet.")
+        if not SquadQueue.queue_command_allowed(interaction.followup, mogi):
             return
 
         player_team = mogi.check_player(member)
@@ -223,8 +235,7 @@ class SquadQueue(commands.Cog):
         await interaction.response.defer()
         
         mogi = self.get_mogi(interaction)
-        if mogi is None or not mogi.started or not mogi.gathering:
-            await interaction.followup.send("Queue has not started yet.")
+        if not SquadQueue.queue_command_allowed(interaction.followup, mogi):
             return
 
         member = interaction.user
@@ -368,8 +379,7 @@ class SquadQueue(commands.Cog):
         await interaction.response.defer()
         async with self.LOCK:
             mogi = self.get_mogi(interaction)
-            if mogi is None or not mogi.started or not mogi.gathering:
-                await interaction.followup.send("Queue has not started yet.")
+            if not SquadQueue.queue_command_allowed(interaction.followup, mogi):
                 return
 
             squad = mogi.check_player(member)

--- a/cogs/SquadQueue.py
+++ b/cogs/SquadQueue.py
@@ -152,9 +152,7 @@ class SquadQueue(commands.Cog):
             print(e)
 
     def get_mogi(self, ctx):
-        if ctx.channel in self.ongoing_events.keys():
-            return self.ongoing_events[ctx.channel]
-        return None
+        return self.ongoing_events.get(ctx.channel):
 
     async def is_started(self, ctx, mogi):
         if not mogi.started:


### PR DESCRIPTION
Refactor to centralize the following common code:
- Checks and sending messages when queueing commands (can, drop, remove player) are sent when the mogi is not started or not gathering
- Checks and sending messages on player being in the queue or not in the queue and sending an invalid command

Basic refactor of get_mogi for conciseness, understandability and efficiency.